### PR TITLE
Add ability to update all tracked mods

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -17,7 +17,8 @@ var addCmd = &cobra.Command{
 	Use:   "add <addon id>",
 	Short: "Add an addon to your list of tracked addons. ",
 	Long: `Add an addon to your list of used addons. This wll immediately download and track
-the addon of your choosing.
+the addon of your choosing. The addon ID can be found under the "Project ID" heading in the "About Project" section of an 
+addon's description
 
 Be sure to only pass 1 addon id per addition. If you pass the id of an already tracked addon this command will simply 
 update that addon in isolation.`,

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -5,8 +5,9 @@ package cmd
 
 import (
 	"fmt"
-
+	"github.com/m-triassi/wowforge-cli/pkg/curseforge"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // updateCmd represents the update command
@@ -14,11 +15,28 @@ var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update all tracked addons",
 	Long: `Fetches the latest version of all addons currently being tracked by wowforge-cli. 
-Simply run the command and all files will be downloaded and unpacked: 
-wowforge-cli update
+Simply run the command and all files will be downloaded and unpacked.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("update called")
+		addons := viper.GetIntSlice("addons")
+
+		for _, id := range addons {
+			files, err := curseforge.GetFiles(id)
+			if err != nil {
+				panic(fmt.Errorf("Failed to fetch files from CurseForge, mod id (%d) may not exist: %w", id, err))
+			}
+
+			file, err := curseforge.DownloadFile(id, curseforge.NegotiateFile(files))
+			if err != nil {
+				panic(fmt.Errorf("Could not download file: %w", err))
+			}
+
+			dest := viper.GetString("install")
+			err = curseforge.InstallAddon(file, dest)
+			if err != nil {
+				panic(fmt.Errorf("Failed to install addon in target destination"))
+			}
+		}
 	},
 }
 


### PR DESCRIPTION
## Summary

Closes #8 

Adds an implementation for the `update` command which loops over all tracked mods and downloads them to the active install directory
